### PR TITLE
New iso debian-8.2.0 (fixes #43)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,8 @@ set -o xtrace
 
 # Configurations
 BOX="debian-jessie"
-ISO_URL="http://cdimage.debian.org/debian-cd/8.1.0/amd64/iso-cd/debian-8.1.0-amd64-netinst.iso"
-ISO_MD5="1a311f9afb68d6365211b13b4342c40b"
+ISO_URL="http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso"
+ISO_MD5="762eb3dfc22f85faf659001ebf270b4f"
 
 # location, location, location
 FOLDER_BASE=$(pwd)


### PR DESCRIPTION
Current build.sh is not working #43 :

```
ERROR: MD5 does not match. Got 5ad6199024b49f8458755350f87a9791 instead of 0b31bccccb048d20b551f70830bb7ad0. Aborting.
```

It was fixed updating the downloaded iso to 8.2.0 