### PR TITLE
Bump to Debian 8.3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script will:
 
- 1. download the `Debian 8.2 "Jessie"` server, 64bit iso
+ 1. download the `Debian 8.3 "Jessie"` server, 64bit iso
  2. ... do some magic to turn it into a vagrant box file
  3. output `debian-jessie.box`
 

--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,8 @@ set -o xtrace
 
 # Configurations
 BOX="debian-jessie"
-ISO_URL="http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso"
-ISO_MD5="762eb3dfc22f85faf659001ebf270b4f"
+ISO_URL="http://cdimage.debian.org/debian-cd/8.3.0/amd64/iso-cd/debian-8.3.0-amd64-netinst.iso"
+ISO_MD5="a9b490b4215d1e72e876b031dafa7184"
 
 # location, location, location
 FOLDER_BASE=$(pwd)


### PR DESCRIPTION
The URL for the 8.2.0 results in a 404 error.